### PR TITLE
Add missing ability and ultimate support for Yuta and Naobito

### DIFF
--- a/jjkcardgame/card_abilities.py
+++ b/jjkcardgame/card_abilities.py
@@ -39,6 +39,8 @@ class CardAbility:
             "Master Tengen": CardAbility.tengen_ability,
             "Ryomen Sukuna": CardAbility.sukuna_ability,
             "Yuki Tsukumo": CardAbility.tsukumo_ability,
+            "Yuta Okkotsu": CardAbility.yuta_ability,
+            "Naobito Zenin": CardAbility.naobito_ability,
             "Ryu": CardAbility.ryu_ability,
             "Reggie": CardAbility.reggie_ability,
             "Dhruv": CardAbility.dhruv_ability,
@@ -374,6 +376,14 @@ class CardAbility:
             game_state['lifesteal'] = 0.5
 
     @staticmethod
+    def naobito_ability(card: Dict[str, Any], game_state: Dict[str, Any]) -> None:
+        if "Clairvoyant Reflexes" in card.get('Effect', ''):
+            game_state['negate_next_attack'] = True
+            game_state['counter_damage'] = 150
+        elif "Instant Acceleration" in card.get('Effect', ''):
+            game_state['extra_attack_if_target_weaker'] = True
+
+    @staticmethod
     def naoya_ability(card: Dict[str, Any], game_state: Dict[str, Any]) -> None:
         if "Projection Sorcery" in card.get('Effect', ''):
             game_state['speed_frames'] = 24
@@ -624,6 +634,8 @@ ABILITIES = {
     "Master Tengen": lambda char, game_state={}: CardAbility.tengen_ability(char, game_state),
     "Ryomen Sukuna": lambda char, game_state={}: CardAbility.sukuna_ability(char, game_state),
     "Yuki Tsukumo": lambda char, game_state={}: CardAbility.tsukumo_ability(char, game_state),
+    "Yuta Okkotsu": lambda char, game_state={}: CardAbility.yuta_ability(char, game_state),
+    "Naobito Zenin": lambda char, game_state={}: CardAbility.naobito_ability(char, game_state),
     "Ryu": lambda char, game_state={}: CardAbility.ryu_ability(char, game_state),
     "Reggie": lambda char, game_state={}: CardAbility.reggie_ability(char, game_state),
     "Dhruv": lambda char, game_state={}: CardAbility.dhruv_ability(char, game_state),

--- a/jjkcardgame/character.py
+++ b/jjkcardgame/character.py
@@ -6,7 +6,11 @@ Handles character creation, ability application, and combat interactions.
 
 from base_types import BaseCharacter
 from typing import Dict, Any, Optional
-from ultimate_abilities import UltimateAbilities, UltimateAbility
+from ultimate_abilities import (
+    UltimateAbilities,
+    UltimateAbility,
+    ULTIMATE_ABILITY_FUNCTIONS,
+)
 
 class Character(BaseCharacter):
     """
@@ -76,24 +80,9 @@ class Character(BaseCharacter):
 
     def get_ultimate_ability(self) -> Optional[UltimateAbility]:
         """Retrieve the ultimate ability for this character based on its name and variant."""
-        character_name = self.name.lower()
-        
-        # Map character names to their respective ultimate methods
-        ultimate_methods = {
-            'gojo satoru': UltimateAbilities.gojo_satoru_ultimate,
-            'fushiguro megumi': UltimateAbilities.fushiguro_megumi_ultimate,
-            'kugisaki nobara': UltimateAbilities.kugisaki_nobara_ultimate,
-            'nanami kento': UltimateAbilities.nanami_kento_ultimate,
-            'kenjaku': UltimateAbilities.kenjaku_ultimate,
-            'naoya zenin': UltimateAbilities.naoya_zenin_ultimate,
-            # Add other characters as needed
-        }
-        
-        # Get the appropriate ultimate method based on character name
-        ultimate_method = ultimate_methods.get(character_name)
-        if ultimate_method:
-            return ultimate_method(self, None, None)  # Pass character data as needed
-        
+        func = ULTIMATE_ABILITY_FUNCTIONS.get(self.name)
+        if func:
+            return func(self, None, None)
         return None
 
     def __init__(self, name, variant, cost, atk, def_, effect='', ultimate='', ultimate_cost=1):

--- a/jjkcardgame/ultimate_abilities.py
+++ b/jjkcardgame/ultimate_abilities.py
@@ -1,4 +1,6 @@
 from typing import Dict, Any, List, Optional
+import csv
+import os
 import random
 
 class UltimateAbility:
@@ -561,6 +563,24 @@ class UltimateAbilities:
         return UltimateAbility("Projection Sorcery", 1.0, {})
 
     @staticmethod
+    def naobito_zenin_ultimate(char: Any, active_player: Any, defending_player: Any) -> UltimateAbility:
+        """Ultimate ability for Naobito Zenin variants."""
+        variant = (char.variant or "").lower()
+        if "former zenin" in variant:
+            return UltimateAbility(
+                name="Projection Overdrive",
+                damage_multiplier=0,
+                effects={'target_disable': 2}
+            )
+        elif "projection sorcery master" in variant:
+            return UltimateAbility(
+                name="Extreme Motion Lock",
+                damage_multiplier=0,
+                effects={'all_enemies_skip_attack': True}
+            )
+        return UltimateAbility("Projection Overdrive", 1.0, {})
+
+    @staticmethod
     def nanami_kento_ultimate(char: Any, active_player: Any, defending_player: Any) -> UltimateAbility:
         """
         Covers:
@@ -651,43 +671,46 @@ class UltimateAbilities:
 
         return UltimateAbility(name, 1.0, effects)
 
+ULTIMATE_ABILITY_FUNCTIONS = {
+    'Gojo Satoru': UltimateAbilities.gojo_satoru_ultimate,
+    'Fushiguro Megumi': UltimateAbilities.fushiguro_megumi_ultimate,
+    'Kugisaki Nobara': UltimateAbilities.kugisaki_nobara_ultimate,
+    'Yuta Okkotsu': UltimateAbilities.yuta_okkotsu_ultimate,
+    'Panda': UltimateAbilities.panda_ultimate,
+    'Kinji Hakari': UltimateAbilities.hakari_kinji_ultimate,
+    'Maki Zenin': UltimateAbilities.maki_zenin_ultimate,
+    'Aoi Todo': UltimateAbilities.todo_aoi_ultimate,
+    'Kirara Hoshi': UltimateAbilities.kirara_hoshi_ultimate,
+    'Toge Inumaki': UltimateAbilities.inumaki_toge_ultimate,
+    'Suguru Geto': UltimateAbilities.geto_suguru_ultimate,
+    'Masamichi Yaga': UltimateAbilities.yaga_masamichi_ultimate,
+    'Shoko Ieiri': UltimateAbilities.shoko_ieiri_ultimate,
+    'Noritoshi Kamo': UltimateAbilities.kamo_noritoshi_ultimate,
+    'Mai Zenin': UltimateAbilities.mai_zenin_ultimate,
+    'Naoya Zenin': UltimateAbilities.naoya_zenin_ultimate,
+    'Naobito Zenin': UltimateAbilities.naobito_zenin_ultimate,
+    'Kento Nanami': UltimateAbilities.nanami_kento_ultimate,
+    'Kenjaku': UltimateAbilities.kenjaku_ultimate,
+}
+
+
 def get_ultimate_ability(character_name: str, variant: str = 'Standard') -> Optional[UltimateAbility]:
-    """
-    Get the ultimate ability for a given character and variant.
-    
-    Args:
-        character_name: Name of the character
-        variant: Variant of the character (default: 'Standard')
-        
-    Returns:
-        UltimateAbility object if one exists for the character, None otherwise
-    """
-    # Define ultimate abilities for different characters
-    ultimate_abilities = {
-        'Gojo Satoru': {
-            'Standard': UltimateAbility(
-                name="Hollow Purple",
-                damage_multiplier=2.5,
-                cooldown=3
-            )
-        },
-        'Yuji Itadori': {
-            'Standard': UltimateAbility(
-                name="Black Flash",
-                damage_multiplier=2.0,
-                cooldown=2
-            )
-        },
-        'Megumi Fushiguro': {
-            'Standard': UltimateAbility(
-                name="Divine Dogs",
-                damage_multiplier=1.8,
-                status_effects=['Bind'],
-                cooldown=2
-            )
-        }
-        # Add more characters and their ultimate abilities here
-    }
-    
-    # Return the ultimate ability if it exists
-    return ultimate_abilities.get(character_name, {}).get(variant)
+    """Return the UltimateAbility for the given character and variant."""
+    func = ULTIMATE_ABILITY_FUNCTIONS.get(character_name)
+    if not func:
+        csv_path = os.path.join(os.path.dirname(__file__), 'characters.csv')
+        try:
+            with open(csv_path) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row['Name'] == character_name and row.get('Variant', 'Standard') == variant:
+                        return UltimateAbility(row['Ultimate Move'], 1.0, {})
+        except FileNotFoundError:
+            return None
+        return None
+
+    class _Char:
+        def __init__(self, variant: str) -> None:
+            self.variant = variant
+
+    return func(_Char(variant), None, None)


### PR DESCRIPTION
## Summary
- Map Yuta Okkotsu and Naobito Zenin abilities and implement Naobito's ability logic
- Add Naobito Zenin ultimate ability and centralize ultimate ability lookup with CSV fallback
- Update Character class to use unified ultimate ability mapping

## Testing
- `python - <<'PY'
import csv, sys
sys.path.append('jjkcardgame')
import card_abilities
with open('jjkcardgame/characters.csv') as f:
    reader = csv.DictReader(f)
    names = set(row['Name'].strip() for row in reader)
abilities = set(card_abilities.ABILITIES.keys())
missing = sorted(names - abilities)
print('Total characters:', len(names))
print('Ability entries:', len(abilities))
print('Missing ability functions:', len(missing))
print('Missing names:', missing)
PY`
- `python - <<'PY'
import csv, sys
sys.path.append('jjkcardgame')
from ultimate_abilities import get_ultimate_ability
missing = []
with open('jjkcardgame/characters.csv') as f:
    reader = csv.DictReader(f)
    for row in reader:
        if not get_ultimate_ability(row['Name'], row['Variant']):
            missing.append((row['Name'], row['Variant']))
print('Missing ultimates:', missing)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a285a7979c8320b95bdd285bb881b3