### PR TITLE
Extract gameplay into engine API and add desktop/web adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # JJKCARDGAME
+
+## Engine/API Contract
+
+Turn and battle logic now lives in `jjkcardgame/engine/` and exposes a serializable API contract:
+
+- `start_game(seed, mode)`
+- `play_card(player_id, hand_index)`
+- `attack(attacker_id, target_id)`
+- `end_turn()`
+
+Both desktop (`jjkcardgame/src/gui.py`) and web (`jjkcardgame/src/web_client.py`) adapters consume this API layer.

--- a/jjkcardgame/engine/__init__.py
+++ b/jjkcardgame/engine/__init__.py
@@ -1,0 +1,5 @@
+"""Engine package exposing game-state API for non-UI clients."""
+
+from .api import GameAPI
+
+__all__ = ["GameAPI"]

--- a/jjkcardgame/engine/api.py
+++ b/jjkcardgame/engine/api.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .game_engine import GameEngine
+
+
+class GameAPI:
+    """Serializable API layer for engine commands."""
+
+    def __init__(self, cards_path: Optional[str] = None):
+        self.engine = GameEngine(cards_path=cards_path)
+
+    def start_game(self, seed: Optional[int], mode: str) -> Dict:
+        return self.engine.start_game(seed=seed, mode=mode)
+
+    def play_card(self, player_id: int, hand_index: int) -> Dict:
+        return self.engine.play_card(player_id=player_id, hand_index=hand_index)
+
+    def attack(self, attacker_id, target_id) -> Dict:
+        return self.engine.attack(attacker_id=attacker_id, target_id=target_id)
+
+    def end_turn(self) -> Dict:
+        return self.engine.end_turn()
+
+    def get_state(self) -> Dict:
+        return self.engine.get_state()

--- a/jjkcardgame/engine/game_engine.py
+++ b/jjkcardgame/engine/game_engine.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from deck import Deck
+from player import Player
+
+
+@dataclass(frozen=True)
+class EntityRef:
+    """Serializable identifier for cards on field."""
+
+    player_id: int
+    index: int
+
+    def as_id(self) -> str:
+        return f"p{self.player_id}:f{self.index}"
+
+
+class GameEngine:
+    """Pure game engine that is independent of any UI framework."""
+
+    def __init__(self, cards_path: Optional[str] = None):
+        self.cards_path = cards_path or str(Path(__file__).resolve().parents[1] / "characters.csv")
+        self.mode: str = "pvp"
+        self.turn: int = 1
+        self.current_player_id: int = 0
+        self.players: List[Player] = []
+        self.winner_id: Optional[int] = None
+        self.last_action: str = ""
+
+    def start_game(self, seed: Optional[int] = None, mode: str = "pvp") -> Dict:
+        if seed is not None:
+            random.seed(seed)
+
+        self.mode = mode
+        self.turn = 1
+        self.current_player_id = 0
+        self.winner_id = None
+        self.last_action = "Game started"
+
+        characters_df = pd.read_csv(self.cards_path)
+        deck1 = Deck(characters_df)
+        deck2 = Deck(characters_df)
+        p1 = Player("Player 1", deck1)
+        p2 = Player("Player 2", deck2)
+        p1.add_energy(1)
+        self.players = [p1, p2]
+        return self.get_state()
+
+    def play_card(self, player_id: int, hand_index: int) -> Dict:
+        self._ensure_started()
+        self._ensure_turn_player(player_id)
+
+        player = self.players[player_id]
+        if hand_index < 0 or hand_index >= len(player.hand):
+            raise ValueError("hand_index out of range")
+
+        card = player.hand[hand_index]
+        if not player.play_card(card):
+            raise ValueError("Card cannot be played (insufficient energy or field full)")
+
+        self.last_action = f"{player.name} played {card.name}"
+        return self.get_state()
+
+    def attack(self, attacker_id, target_id) -> Dict:
+        self._ensure_started()
+        attacker_ref = self._parse_ref(attacker_id)
+        target_ref = self._parse_ref(target_id) if target_id is not None else None
+
+        self._ensure_turn_player(attacker_ref.player_id)
+        attacker_owner = self.players[attacker_ref.player_id]
+        defender_owner = self.players[1 - attacker_ref.player_id]
+
+        attacker = self._get_field_card(attacker_ref)
+        if target_ref is None:
+            defender_owner.take_damage(attacker.atk)
+            self.last_action = f"{attacker.name} attacked {defender_owner.name} directly for {attacker.atk}"
+        else:
+            target = self._get_field_card(target_ref)
+            damage = target.take_damage(attacker.atk)
+            self.last_action = f"{attacker.name} attacked {target.name} for {damage}"
+            if not target.is_alive():
+                self.players[target_ref.player_id].field.pop(target_ref.index)
+
+        self._update_winner()
+        return self.get_state()
+
+    def end_turn(self) -> Dict:
+        self._ensure_started()
+        self.current_player_id = 1 - self.current_player_id
+        self.turn += 1
+
+        current = self.players[self.current_player_id]
+        current.add_energy(1)
+        current.draw_cards(1)
+        self.last_action = f"Turn ended. {current.name}'s turn."
+        return self.get_state()
+
+    def get_state(self) -> Dict:
+        players_state = []
+        for player_id, player in enumerate(self.players):
+            hand = [
+                {
+                    "name": c.name,
+                    "variant": c.variant,
+                    "cost": c.cost,
+                    "atk": c.atk,
+                    "defense": c.def_val,
+                    "current_health": c.current_health,
+                }
+                for c in player.hand
+            ]
+            field = [
+                {
+                    "id": EntityRef(player_id, idx).as_id(),
+                    "name": c.name,
+                    "variant": c.variant,
+                    "cost": c.cost,
+                    "atk": c.atk,
+                    "defense": c.def_val,
+                    "current_health": c.current_health,
+                }
+                for idx, c in enumerate(player.field)
+            ]
+
+            players_state.append(
+                {
+                    "player_id": player_id,
+                    "name": player.name,
+                    "life_points": player.life_points,
+                    "energy": player.energy,
+                    "deck_count": player.deck.cards_remaining(),
+                    "hand": hand,
+                    "field": field,
+                }
+            )
+
+        return {
+            "mode": self.mode,
+            "turn": self.turn,
+            "current_player_id": self.current_player_id,
+            "winner_id": self.winner_id,
+            "last_action": self.last_action,
+            "players": players_state,
+        }
+
+    def _ensure_started(self) -> None:
+        if not self.players:
+            raise ValueError("Game not started. Call start_game first")
+
+    def _ensure_turn_player(self, player_id: int) -> None:
+        if player_id != self.current_player_id:
+            raise ValueError("Not this player's turn")
+
+    def _update_winner(self) -> None:
+        if self.players[0].life_points <= 0:
+            self.winner_id = 1
+        elif self.players[1].life_points <= 0:
+            self.winner_id = 0
+
+    def _parse_ref(self, ref) -> EntityRef:
+        if isinstance(ref, dict):
+            return EntityRef(int(ref["player_id"]), int(ref["index"]))
+
+        if isinstance(ref, (tuple, list)) and len(ref) == 2:
+            return EntityRef(int(ref[0]), int(ref[1]))
+
+        if isinstance(ref, str) and ref.startswith("p") and ":f" in ref:
+            player_raw, index_raw = ref.split(":f", maxsplit=1)
+            return EntityRef(int(player_raw[1:]), int(index_raw))
+
+        raise ValueError("Invalid entity reference format")
+
+    def _get_field_card(self, ref: EntityRef):
+        player = self.players[ref.player_id]
+        if ref.index < 0 or ref.index >= len(player.field):
+            raise ValueError("Field index out of range")
+        return player.field[ref.index]

--- a/jjkcardgame/src/gui.py
+++ b/jjkcardgame/src/gui.py
@@ -1,20 +1,17 @@
 import tkinter as tk
 from tkinter import messagebox, simpledialog
-from player import Player
-from deck import Deck
-from battle import Battle
-from character import Character
-import pandas as pd
+
+from engine import GameAPI
+
 
 class JJKCardGameGUI:
+    """Desktop adapter for the serializable game API."""
+
     def __init__(self, master):
         self.master = master
         self.master.title("JJK Card Game")
-        
-        self.player1 = None
-        self.player2 = None
-        self.battle = None
-        
+        self.api = GameAPI()
+        self.state = None
         self.setup_ui()
 
     def setup_ui(self):
@@ -38,19 +35,9 @@ class JJKCardGameGUI:
         self.game_frame = None
 
     def start_game(self):
-        player1_name = self.player1_name_entry.get()
-        player2_name = self.player2_name_entry.get()
-
-        # Load characters from CSV
-        characters_df = pd.read_csv("characters.csv")
-        deck1 = Deck(characters_df)
-        deck2 = Deck(characters_df)
-
-        self.player1 = Player(player1_name, deck1)
-        self.player2 = Player(player2_name, deck2)
-        self.battle = Battle(self.player1, self.player2)
-
+        self.state = self.api.start_game(seed=None, mode="desktop")
         self.setup_game_ui()
+        self.refresh_labels()
 
     def setup_game_ui(self):
         if self.game_frame:
@@ -59,65 +46,121 @@ class JJKCardGameGUI:
         self.game_frame = tk.Frame(self.master)
         self.game_frame.pack(pady=20)
 
-        self.turn_label = tk.Label(self.game_frame, text=f"{self.player1.name}'s Turn")
-        self.turn_label.grid(row=0, columnspan=2)
+        self.turn_label = tk.Label(self.game_frame, text="")
+        self.turn_label.grid(row=0, columnspan=3)
 
         self.play_button = tk.Button(self.game_frame, text="Play Card", command=self.choose_card)
         self.play_button.grid(row=1, column=0, padx=5)
 
+        self.attack_button = tk.Button(self.game_frame, text="Attack", command=self.attack)
+        self.attack_button.grid(row=1, column=1, padx=5)
+
         self.end_turn_button = tk.Button(self.game_frame, text="End Turn", command=self.end_turn)
-        self.end_turn_button.grid(row=1, column=1, padx=5)
+        self.end_turn_button.grid(row=1, column=2, padx=5)
 
         self.status_label = tk.Label(self.game_frame, text="")
-        self.status_label.grid(row=2, columnspan=2)
+        self.status_label.grid(row=2, columnspan=3)
 
         self.stats_button = tk.Button(self.game_frame, text="Show Stats", command=self.show_stats)
-        self.stats_button.grid(row=3, columnspan=2, pady=10)
+        self.stats_button.grid(row=3, columnspan=3, pady=10)
+
+    def refresh_labels(self):
+        player = self.state["players"][self.state["current_player_id"]]
+        self.turn_label.config(text=f"{player['name']}'s Turn")
+        self.status_label.config(text=self.state.get("last_action", ""))
 
     def show_stats(self):
+        p1 = self.state["players"][0]
+        p2 = self.state["players"][1]
         stats_message = (
-            f"{self.player1.name} - Life Points: {self.player1.life_points}, Energy: {self.player1.energy}\n"
-            f"{self.player2.name} - Life Points: {self.player2.life_points}, Energy: {self.player2.energy}\n\n"
-            f"{self.player1.name}'s Field: {[char.name for char in self.player1.field]}\n"
-            f"{self.player2.name}'s Field: {[char.name for char in self.player2.field]}"
+            f"{p1['name']} - Life Points: {p1['life_points']}, Energy: {p1['energy']}\n"
+            f"{p2['name']} - Life Points: {p2['life_points']}, Energy: {p2['energy']}\n\n"
+            f"{p1['name']}'s Field: {[char['name'] for char in p1['field']]}\n"
+            f"{p2['name']}'s Field: {[char['name'] for char in p2['field']]}"
         )
         messagebox.showinfo("Player Stats", stats_message)
 
     def choose_card(self):
-        current_player = self.battle.player1 if self.battle.current_turn % 2 != 0 else self.battle.player2
-        if not current_player.hand:
-            self.status_label.config(text=f"{current_player.name} has no cards to play.")
+        current_player_id = self.state["current_player_id"]
+        current_player = self.state["players"][current_player_id]
+
+        if not current_player["hand"]:
+            self.status_label.config(text=f"{current_player['name']} has no cards to play.")
             return
 
         card_details = []
-        for index, card in enumerate(current_player.hand):
-            details = f"{index + 1}. {card.name} (Cost: {card.cost}, ATK: {card.atk}, DEF: {card.defense})"
+        for index, card in enumerate(current_player["hand"]):
+            details = f"{index + 1}. {card['name']} (Cost: {card['cost']}, ATK: {card['atk']}, DEF: {card['defense']})"
             card_details.append(details)
 
         card_selection_message = "\n".join(card_details) + "\n\nType the number of the card to play:"
         selected_index = simpledialog.askinteger("Choose Card", card_selection_message)
 
-        if selected_index is not None and 1 <= selected_index <= len(current_player.hand):
-            card = current_player.hand[selected_index - 1]
-            if current_player.play_card(card):
-                self.status_label.config(text=f"{current_player.name} played {card.name}.")
-            else:
-                self.status_label.config(text=f"{current_player.name} cannot play {card.name}.")
+        if selected_index is not None and 1 <= selected_index <= len(current_player["hand"]):
+            try:
+                self.state = self.api.play_card(current_player_id, selected_index - 1)
+                self.refresh_labels()
+            except ValueError as error:
+                self.status_label.config(text=str(error))
         else:
             self.status_label.config(text="Invalid card selection.")
 
-    def end_turn(self):
-        self.battle.current_turn += 1
-        self.turn_label.config(text=f"{self.battle.player1.name if self.battle.current_turn % 2 != 0 else self.battle.player2.name}'s Turn")
-        self.status_label.config(text="")
+    def attack(self):
+        current_player_id = self.state["current_player_id"]
+        current_player = self.state["players"][current_player_id]
+        opponent_id = 1 - current_player_id
+        opponent = self.state["players"][opponent_id]
 
-        # Check for game end condition
-        if self.battle.player1.life_points <= 0 or self.battle.player2.life_points <= 0:
-            winner = self.battle.player1 if self.battle.player1.is_alive() else self.battle.player2
-            messagebox.showinfo("Game Over", f"{winner.name} wins!")
-            self.master.quit()
+        if not current_player["field"]:
+            self.status_label.config(text="No attackers on field.")
+            return
+
+        attacker_prompt = "\n".join(
+            [f"{idx + 1}. {card['name']}" for idx, card in enumerate(current_player["field"])]
+        )
+        attacker_index = simpledialog.askinteger("Choose Attacker", attacker_prompt)
+        if attacker_index is None or not (1 <= attacker_index <= len(current_player["field"])):
+            self.status_label.config(text="Invalid attacker selection.")
+            return
+
+        target_id = None
+        if opponent["field"]:
+            target_prompt = "0. Attack player directly\n" + "\n".join(
+                [f"{idx + 1}. {card['name']}" for idx, card in enumerate(opponent["field"])]
+            )
+            target_index = simpledialog.askinteger("Choose Target", target_prompt)
+            if target_index is None:
+                self.status_label.config(text="Attack cancelled.")
+                return
+            if target_index != 0:
+                if not (1 <= target_index <= len(opponent["field"])):
+                    self.status_label.config(text="Invalid target selection.")
+                    return
+                target_id = opponent["field"][target_index - 1]["id"]
+
+        attacker_id = current_player["field"][attacker_index - 1]["id"]
+        try:
+            self.state = self.api.attack(attacker_id=attacker_id, target_id=target_id)
+            self.refresh_labels()
+            self._check_winner()
+        except ValueError as error:
+            self.status_label.config(text=str(error))
+
+    def end_turn(self):
+        self.state = self.api.end_turn()
+        self.refresh_labels()
+        self._check_winner()
+
+    def _check_winner(self):
+        winner_id = self.state.get("winner_id")
+        if winner_id is None:
+            return
+        winner_name = self.state["players"][winner_id]["name"]
+        messagebox.showinfo("Game Over", f"{winner_name} wins!")
+        self.master.quit()
+
 
 if __name__ == "__main__":
     root = tk.Tk()
     app = JJKCardGameGUI(root)
-    root.mainloop() 
+    root.mainloop()

--- a/jjkcardgame/src/web_client.py
+++ b/jjkcardgame/src/web_client.py
@@ -1,0 +1,27 @@
+"""Web-facing adapter that consumes the serializable GameAPI contract."""
+
+from engine import GameAPI
+
+
+class WebGameClient:
+    """Thin adapter for web clients to call engine commands."""
+
+    def __init__(self):
+        self.api = GameAPI()
+
+    def dispatch(self, command: str, payload: dict):
+        if command == "start_game":
+            return self.api.start_game(seed=payload.get("seed"), mode=payload.get("mode", "web"))
+        if command == "play_card":
+            return self.api.play_card(
+                player_id=payload["player_id"],
+                hand_index=payload["hand_index"],
+            )
+        if command == "attack":
+            return self.api.attack(
+                attacker_id=payload["attacker_id"],
+                target_id=payload.get("target_id"),
+            )
+        if command == "end_turn":
+            return self.api.end_turn()
+        raise ValueError(f"Unsupported command: {command}")

--- a/jjkcardgame/test_engine_api.py
+++ b/jjkcardgame/test_engine_api.py
@@ -1,0 +1,26 @@
+import unittest
+
+from engine import GameAPI
+
+
+class TestGameAPI(unittest.TestCase):
+    def setUp(self):
+        self.api = GameAPI()
+        self.state = self.api.start_game(seed=42, mode="test")
+
+    def test_start_game_contract(self):
+        self.assertIn("players", self.state)
+        self.assertIn("current_player_id", self.state)
+        self.assertEqual(self.state["mode"], "test")
+
+    def test_play_card_and_end_turn(self):
+        current = self.state["players"][0]
+        playable_index = next(i for i, card in enumerate(current["hand"]) if card["cost"] <= current["energy"])
+        updated = self.api.play_card(0, playable_index)
+        self.assertEqual(updated["current_player_id"], 0)
+        ended = self.api.end_turn()
+        self.assertEqual(ended["current_player_id"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Separate core turn and battle logic from the `tkinter` UI so game rules can be reused by other clients. 
- Provide a serializable, UI-agnostic game-state API so web and other front-ends can interact with the engine via a simple command surface. 
- Make the desktop GUI a thin adapter that consumes the engine API rather than owning game flow or mutating game objects directly. 

### Description
- Added a new engine package `jjkcardgame/engine/` with a pure-Python `GameEngine` that implements lifecycle and game commands and returns serializable state dictionaries. 
- Exposed a thin API layer `GameAPI` with the requested contract: `start_game(seed, mode)`, `play_card(player_id, hand_index)`, `attack(attacker_id, target_id)`, and `end_turn()`. 
- Refactored `jjkcardgame/src/gui.py` into a desktop adapter that calls `GameAPI` and renders returned state instead of directly manipulating `Battle`/`Player` objects. 
- Added `jjkcardgame/src/web_client.py` as a web-facing adapter that dispatches the same API commands and added `jjkcardgame/test_engine_api.py` plus README updates documenting the API contract. 

### Testing
- Compiled engine and adapters with `python -m py_compile jjkcardgame/engine/api.py jjkcardgame/engine/game_engine.py jjkcardgame/src/gui.py jjkcardgame/src/web_client.py` and the compilation succeeded. 
- Ran unit tests with `cd jjkcardgame && python -m unittest test_engine_api.py` which executed 2 tests and reported `OK`. 
- Performed a smoke run using the API (`start_game`, a playable `play_card`, then `end_turn`) which completed and returned updated serializable state as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b34a1c2ca883209a49154e9dc459f9)